### PR TITLE
[FIX] use "export type" due to stricter type checks in deno 1.5+

### DIFF
--- a/deno/index.ts
+++ b/deno/index.ts
@@ -1,3 +1,8 @@
-export { Either, Left, Right, isLeft, isRight } from './either/either.ts';
-export { Option, Some, None, isSome, isNone } from './option/option.ts';
-export { Result, Ok, Err, isOk, isErr } from './result/result.ts';
+export type { Either } from "./either/either.ts";
+export { isLeft, isRight, Left, Right } from "./either/either.ts";
+
+export type { Option } from "./option/option.ts";
+export { isNone, isSome, None, Some } from "./option/option.ts";
+
+export type { Result } from "./result/result.ts";
+export { Err, isErr, isOk, Ok } from "./result/result.ts";


### PR DESCRIPTION
Hi, 

I'm getting an import error from monads 0.5.8. Please see the error message below. 

After some googling, I find it is due to the stricter type checks in deno 1.5+ (I'm using deno 1.16.4). 

One way to fix it is to use the "export type" keywords instead of export.

Alternatively, the users of this library must disable the `isolatedModules` flag in tsconfig.json (which could be annoying).

I have run all the tests and found no issues. 

Please take a look. 

Thank you!

```
error: TS1205 [ERROR]: Re-exporting a type when the '--isolatedModules' flag is provided requires using 'export type'.
export { Either, Left, Right, isLeft, isRight } from './either/either.ts';
         ~~~~~~
    at https://deno.land/x/monads@v0.5.8/index.ts:1:10

TS1205 [ERROR]: Re-exporting a type when the '--isolatedModules' flag is provided requires using 'export type'.
export { Option, Some, None, isSome, isNone } from './option/option.ts';
         ~~~~~~
    at https://deno.land/x/monads@v0.5.8/index.ts:2:10

TS1205 [ERROR]: Re-exporting a type when the '--isolatedModules' flag is provided requires using 'export type'.
export { Result, Ok, Err, isOk, isErr } from './result/result.ts';
         ~~~~~~
    at https://deno.land/x/monads@v0.5.8/index.ts:3:10

Found 3 errors.
The terminal process "deno 'test', '--allow-all', '--filter', 'fp maybe monad', '/home/weining/work/dev/ts/github.com/powergun/denoExamples/src/fp/maybe/optional.test.ts'" terminated with exit code: 1.
```