### PR TITLE
Update isErr function to narrow the input value to an error result

### DIFF
--- a/lib/result/result.ts
+++ b/lib/result/result.ts
@@ -145,6 +145,6 @@ export function isOk<T, E>(val: Result<T, E>): val is ResOk<T> {
   return val.isOk();
 }
 
-export function isErr<T, E>(val: Result<T, E>): val is ResErr<T, E> {
+export function isErr<T, E>(val: Result<T, E>): val is ResErr<never, E> {
   return val.isErr();
 }


### PR DESCRIPTION
PR updates `isErr` function to improve its accuracy by narrowing the input value to only return error results.

Closes #94 